### PR TITLE
Use annotated tags for releases

### DIFF
--- a/src/Vcs/Git.php
+++ b/src/Vcs/Git.php
@@ -30,7 +30,6 @@ final class Git implements VersionControlSystem
             $tag = $this->executeGitCommand(
                 'describe',
                 [
-                    '--tags',
                     '--abbrev=0',
                     sprintf('--match "%s%s"', $this->tagPrefix, self::VERSION_GLOB),
                 ]
@@ -48,7 +47,14 @@ final class Git implements VersionControlSystem
 
     public function createVersion(string $version): void
     {
-        $this->executeGitCommand('tag', [$this->tagPrefix . $version]);
+        $this->executeGitCommand(
+            'tag',
+            [
+                '--annotate',
+                $this->tagPrefix . $version,
+                sprintf('--message="Release %s"', $version),
+            ]
+        );
     }
 
     /**

--- a/tests/integration/Vcs/GitTest.php
+++ b/tests/integration/Vcs/GitTest.php
@@ -103,12 +103,12 @@ class GitTest extends TestCase
         $tag = self::TEST_TAG_PREFIX . $tag;
 
         if ($head !== null) {
-            exec('git tag ' . $tag . ' ' . $head);
+            exec('git tag --annotate --message="Test tag" ' . $tag . ' ' . $head);
 
             return;
         }
 
-        exec('git tag ' . $tag);
+        exec('git tag --annotate --message="Test tag" ' . $tag);
     }
 
     private function deleteTestTags(): void


### PR DESCRIPTION
> Annotated tags, however, are stored as full objects in the Git database. They’re checksummed; contain the tagger name, email, and date; have a tagging message; and can be signed and verified with GNU Privacy Guard (GPG). It’s generally recommended that you create annotated tags so you can have all this information; but if you want a temporary tag or for some reason don’t want to keep the other information, lightweight tags are available too.

https://git-scm.com/book/en/v2/Git-Basics-Tagging