### PR TITLE
Update to the latest version of the LEVIY Coding Standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "behat/behat": "^3.4",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "leviy/coding-standard": "^3.4",
+        "leviy/coding-standard": "^3.5",
         "mockery/mockery": "^1.1",
         "phpstan/phpstan": "^0.9.2",
         "phpunit/phpunit": "^7.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fe27deb6b643e251cf65d71a5eb5b52",
+    "content-hash": "60071793e4cfe2188ff021255ccf0676",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1640,16 +1640,16 @@
         },
         {
             "name": "leviy/coding-standard",
-            "version": "v3.4.4",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/leviy/php-coding-standard.git",
-                "reference": "209bde5a1c0127e0506119485b866b129b92c8e6"
+                "reference": "385a80213f867c1ec3b25301237d55201bb64adc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/leviy/php-coding-standard/zipball/209bde5a1c0127e0506119485b866b129b92c8e6",
-                "reference": "209bde5a1c0127e0506119485b866b129b92c8e6",
+                "url": "https://api.github.com/repos/leviy/php-coding-standard/zipball/385a80213f867c1ec3b25301237d55201bb64adc",
+                "reference": "385a80213f867c1ec3b25301237d55201bb64adc",
                 "shasum": ""
             },
             "require": {
@@ -1657,7 +1657,7 @@
                 "escapestudios/symfony2-coding-standard": "^3.0",
                 "php": "^7.1",
                 "phpmd/phpmd": "^2.6",
-                "slevomat/coding-standard": "^4.5",
+                "slevomat/coding-standard": "^4.6",
                 "squizlabs/php_codesniffer": "^3.0"
             },
             "require-dev": {
@@ -1680,7 +1680,7 @@
                 }
             ],
             "description": "LEVIY Coding Standard",
-            "time": "2018-08-01T09:22:48+00:00"
+            "time": "2018-11-09T14:44:14+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/src/GitHub/GitHubRepositoryParser.php
+++ b/src/GitHub/GitHubRepositoryParser.php
@@ -20,8 +20,6 @@ class GitHubRepositoryParser
     }
 
     /**
-     * @param string $url
-     *
      * @return string[]
      */
     private function parseUrl(string $url): array

--- a/src/Interaction/InformationCollector.php
+++ b/src/Interaction/InformationCollector.php
@@ -8,11 +8,7 @@ interface InformationCollector
     public function askConfirmation(string $question): bool;
 
     /**
-     * @param string      $question
-     * @param string[]    $choices
-     * @param string|null $default
-     *
-     * @return string
+     * @param string[] $choices
      */
     public function askMultipleChoice(string $question, array $choices, ?string $default = null): string;
 }

--- a/src/ReleaseAction/ReleaseAction.php
+++ b/src/ReleaseAction/ReleaseAction.php
@@ -8,10 +8,7 @@ use Leviy\ReleaseTool\Versioning\Version;
 interface ReleaseAction
 {
     /**
-     * @param Version  $version
      * @param string[] $changeset
-     *
-     * @return void
      */
     public function execute(Version $version, array $changeset): void;
 }

--- a/src/ReleaseManager.php
+++ b/src/ReleaseManager.php
@@ -34,10 +34,7 @@ class ReleaseManager
     private $actions;
 
     /**
-     * @param VersionControlSystem $versionControlSystem
-     * @param VersioningScheme     $versioningScheme
-     * @param ChangelogGenerator   $changelogGenerator
-     * @param ReleaseAction[]      $actions
+     * @param ReleaseAction[] $actions
      */
     public function __construct(
         VersionControlSystem $versionControlSystem,

--- a/src/Vcs/Git.php
+++ b/src/Vcs/Git.php
@@ -31,7 +31,6 @@ final class Git implements VersionControlSystem
     }
 
     /**
-     * @param string   $command
      * @param string[] $arguments
      *
      * @return string[]
@@ -92,8 +91,6 @@ final class Git implements VersionControlSystem
     }
 
     /**
-     * @param null|string $pattern
-     *
      * @return Commit[]
      */
     public function getCommitsSinceLastVersion(?string $pattern = null): array

--- a/src/Vcs/VersionControlSystem.php
+++ b/src/Vcs/VersionControlSystem.php
@@ -12,8 +12,6 @@ interface VersionControlSystem
     public function pushVersion(string $version): void;
 
     /**
-     * @param null|string $pattern
-     *
      * @return Commit[]
      */
     public function getCommitsSinceLastVersion(?string $pattern = null): array;

--- a/tests/unit/GitHub/GitHubRepositoryParserTest.php
+++ b/tests/unit/GitHub/GitHubRepositoryParserTest.php
@@ -11,9 +11,6 @@ class GitHubRepositoryParserTest extends TestCase
 {
     /**
      * @dataProvider ownerProvider
-     *
-     * @param string $url
-     * @param string $owner
      */
     public function testThatOwnerIsReturned(string $url, string $owner): void
     {
@@ -36,9 +33,6 @@ class GitHubRepositoryParserTest extends TestCase
 
     /**
      * @dataProvider repositoryNameProvider
-     *
-     * @param string $url
-     * @param string $repository
      */
     public function testThatRepositoryNameIsReturned(string $url, string $repository): void
     {


### PR DESCRIPTION
From version 3.5.0 the coding standard no longer allows "useless" `@param` and `@return` annotations (i.e. those that are redundant because of native type declarations).

This PR updates the coding standard and removes useless annotations.