### PR TITLE
Remove PHP-Parallel-Lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dist: build/release-tool.phar
 check test: static-analysis unit-tests integration-tests acceptance-tests system-tests coding-standards security-tests
 
 static-analysis: vendor
-	vendor/bin/phpstan analyse --level=7 --configuration=phpstan.neon $(sources)
+	vendor/bin/phpstan analyse
 
 unit-tests: vendor
 	vendor/bin/phpunit --testsuite unit-tests

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ dist: build/release-tool.phar
 check test: static-analysis unit-tests integration-tests acceptance-tests system-tests coding-standards security-tests
 
 static-analysis: vendor
-	vendor/bin/parallel-lint $(sources)
 	vendor/bin/phpstan analyse --level=7 --configuration=phpstan.neon $(sources)
 
 unit-tests: vendor

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,6 @@
     },
     "require-dev": {
         "behat/behat": "^3.4",
-        "jakub-onderka/php-console-highlighter": "^0.3.2",
-        "jakub-onderka/php-parallel-lint": "^1.0",
         "leviy/coding-standard": "^3.5",
         "mockery/mockery": "^1.1",
         "phpstan/phpstan": "^0.11.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75f597c2d3e0f4b20e86736d19b27ee1",
+    "content-hash": "c60c58c466d9924585a90b92e5c51710",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1600,140 +1600,6 @@
                 "test"
             ],
             "time": "2016-01-20T08:20:44+00:00"
-        },
-        {
-            "name": "jakub-onderka/php-console-color",
-            "version": "v0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Console-Color.git",
-                "reference": "d5deaecff52a0d61ccb613bb3804088da0307191"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Color/zipball/d5deaecff52a0d61ccb613bb3804088da0307191",
-                "reference": "d5deaecff52a0d61ccb613bb3804088da0307191",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "jakub-onderka/php-code-style": "1.0",
-                "jakub-onderka/php-parallel-lint": "1.0",
-                "jakub-onderka/php-var-dump-check": "0.*",
-                "phpunit/phpunit": "~4.3",
-                "squizlabs/php_codesniffer": "1.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "JakubOnderka\\PhpConsoleColor\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "jakub.onderka@gmail.com"
-                }
-            ],
-            "time": "2018-09-29T17:23:10+00:00"
-        },
-        {
-            "name": "jakub-onderka/php-console-highlighter",
-            "version": "v0.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Console-Highlighter.git",
-                "reference": "7daa75df45242c8d5b75a22c00a201e7954e4fb5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Highlighter/zipball/7daa75df45242c8d5b75a22c00a201e7954e4fb5",
-                "reference": "7daa75df45242c8d5b75a22c00a201e7954e4fb5",
-                "shasum": ""
-            },
-            "require": {
-                "jakub-onderka/php-console-color": "~0.1",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "jakub-onderka/php-code-style": "~1.0",
-                "jakub-onderka/php-parallel-lint": "~0.5",
-                "jakub-onderka/php-var-dump-check": "~0.1",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "JakubOnderka\\PhpConsoleHighlighter": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "acci@acci.cz",
-                    "homepage": "http://www.acci.cz/"
-                }
-            ],
-            "time": "2015-04-20T18:58:01+00:00"
-        },
-        {
-            "name": "jakub-onderka/php-parallel-lint",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
-                "reference": "04fbd3f5fb1c83f08724aa58a23db90bd9086ee8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/04fbd3f5fb1c83f08724aa58a23db90bd9086ee8",
-                "reference": "04fbd3f5fb1c83f08724aa58a23db90bd9086ee8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "~0.3",
-                "nette/tester": "~1.3",
-                "squizlabs/php_codesniffer": "~2.7"
-            },
-            "suggest": {
-                "jakub-onderka/php-console-highlighter": "Highlight syntax in code snippet"
-            },
-            "bin": [
-                "parallel-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "./"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "ahoj@jakubonderka.cz"
-                }
-            ],
-            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
-            "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2018-02-24T15:31:20+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,8 @@
 parameters:
+    level: max
+    paths:
+        - bin/release
+        - src
     ignoreErrors:
         # Only available in ArrayNodeDefinition which is given
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)\.#'


### PR DESCRIPTION
PHPStan will also report syntax errors, so running PHP-Parallel-Lint is redundant.

- [x] The pull request is complete according to the [Definition of Done](https://sites.google.com/leviy.com/development/development/definition-of-done)
  - [ ] Acceptance criteria in the ticket have been met
  - [ ] Automated tests are written according to the [test plan](https://docs.google.com/document/d/106bwyTS-gIrT7edLW4_5pCl6DSDaZBEMiiyBw1za0R8/edit#heading=h.5ybg7xjjzlkj)
  - [ ] The documentation is up-to-date
  - [ ] Deployment automation includes newly introduced environment variables and credentials are added to the credentials.fact file of all servers
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] When applicable, the pull request title starts with the issue number
