### PR TITLE
Fix first release without specifying version

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -72,6 +72,7 @@ class FeatureContext implements Context
      */
     public function aReleaseOnThisBranchWithVersion(string $version): void
     {
+        $this->versionControlSystem->shouldReceive('findLastVersion')->andReturn(true);
         $this->versionControlSystem->shouldReceive('getLastVersion')->andReturn($version);
     }
 

--- a/src/ReleaseManager.php
+++ b/src/ReleaseManager.php
@@ -47,6 +47,11 @@ class ReleaseManager
         return $this->versionControlSystem->getLastVersion();
     }
 
+    public function hasVersions(): bool
+    {
+        return $this->versionControlSystem->findLastVersion() !== null;
+    }
+
     public function release(string $versionString, InformationCollector $informationCollector): void
     {
         $this->versionControlSystem->createVersion($versionString);
@@ -72,6 +77,10 @@ class ReleaseManager
 
     public function determineNextVersion(InformationCollector $informationCollector): string
     {
+        if ($this->versionControlSystem->findLastVersion() === null) {
+            return '1.0.0';
+        }
+
         $current = $this->versionControlSystem->getLastVersion();
         $currentVersion = $this->versioningScheme->getVersion($current);
 
@@ -80,6 +89,14 @@ class ReleaseManager
 
     public function determineNextPreReleaseVersion(InformationCollector $informationCollector): string
     {
+        if ($this->versionControlSystem->findLastVersion() === null) {
+            $currentVersion = $this->versioningScheme->getVersion('0.0.0');
+
+            return $this->versioningScheme
+                ->getNextPreReleaseVersion($currentVersion, $informationCollector)
+                ->getVersion();
+        }
+
         $current = $this->versionControlSystem->getLastVersion();
         $currentVersion = $this->versioningScheme->getVersion($current);
 

--- a/src/Vcs/Git.php
+++ b/src/Vcs/Git.php
@@ -60,6 +60,17 @@ class Git implements VersionControlSystem
         return $this->getVersionFromTag($tag);
     }
 
+    public function findLastVersion(): ?string
+    {
+        try {
+            $tag = $this->describe();
+        } catch (ReleaseNotFoundException $exception) {
+            return null;
+        }
+
+        return $this->getVersionFromTag($tag);
+    }
+
     public function createVersion(string $version): void
     {
         self::execute(

--- a/src/Vcs/VersionControlSystem.php
+++ b/src/Vcs/VersionControlSystem.php
@@ -7,6 +7,8 @@ interface VersionControlSystem
 {
     public function getLastVersion(): string;
 
+    public function findLastVersion(): ?string;
+
     public function createVersion(string $version): void;
 
     public function pushVersion(string $version): void;

--- a/tests/system/ApplicationTest.php
+++ b/tests/system/ApplicationTest.php
@@ -79,6 +79,27 @@ class ApplicationTest extends TestCase
         $this->assertSame(['v1.0.0'], $this->getTags());
     }
 
+    public function testReleasesWithoutGivenVersionNumber(): void
+    {
+        $this->commitFile('README.md', 'First commit');
+
+        $input = new InputStream();
+
+        $process = new Process(['build/release-tool.phar', 'release']);
+        $process->setInput($input);
+        $process->start();
+
+        // EOL simulates [Enter]
+        // Do you want to continue? (yes/no)
+        $input->write('no' . PHP_EOL);
+        $input->close();
+
+        $process->wait();
+
+        $this->assertStringContainsString('This will release version 1.0.0.', $process->getOutput());
+        $this->assertStringContainsString('Do you want to continue?', $process->getOutput());
+    }
+
     public function testShowsTheChangelogBeforeAskingInteractiveQuestions(): void
     {
         $this->commitFile('README.md', 'Initial commit');


### PR DESCRIPTION
[#43] The first release can't calculate the first version and has to be specified manually.

Now you can release the first version without specifying a version number.
