### PR TITLE
Fix error when called outside a git directory

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Leviy\ReleaseTool\Console\Application;
+use Leviy\ReleaseTool\Vcs\MissingConfigurationException;
+use Leviy\ReleaseTool\Vcs\RepositoryNotFoundException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 if (file_exists(__DIR__ . '/../../../autoload.php')) {
@@ -12,6 +14,11 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
 }
 
 $container = new ContainerBuilder();
-$application = new Application($container);
+try {
+    $application = new Application($container);
+} catch (RepositoryNotFoundException | MissingConfigurationException $exception) {
+    echo $exception->getMessage() . PHP_EOL;
+    exit(1);
+}
 
 $application->run();

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -6,6 +6,7 @@ namespace Leviy\ReleaseTool\Console;
 use Leviy\ReleaseTool\Configuration\CredentialsConfiguration;
 use Leviy\ReleaseTool\GitHub\GitHubRepositoryParser;
 use Leviy\ReleaseTool\Vcs\Git;
+use Leviy\ReleaseTool\Vcs\MissingConfigurationException;
 use RuntimeException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
@@ -76,7 +77,7 @@ final class Application extends SymfonyApplication
         $configFile = $homeDirectory . '/.release-tool/auth.yml';
 
         if (!file_exists($configFile)) {
-            throw new RuntimeException(
+            throw new MissingConfigurationException(
                 sprintf('The file %s needs to exist and contain a GitHub access token', $configFile)
             );
         }

--- a/src/Vcs/MissingConfigurationException.php
+++ b/src/Vcs/MissingConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Leviy\ReleaseTool\Vcs;
+
+use RuntimeException;
+
+final class MissingConfigurationException extends RuntimeException
+{
+}

--- a/src/Vcs/RepositoryNotFoundException.php
+++ b/src/Vcs/RepositoryNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Leviy\ReleaseTool\Vcs;
+
+use RuntimeException;
+
+final class RepositoryNotFoundException extends RuntimeException
+{
+}

--- a/tests/integration/Vcs/GitTest.php
+++ b/tests/integration/Vcs/GitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Leviy\ReleaseTool\Tests\Integration\Vcs;
 
 use Leviy\ReleaseTool\Vcs\Git;
-use Leviy\ReleaseTool\Vcs\RepositoryNotFoundException;
+use Leviy\ReleaseTool\Vcs\ReleaseNotFoundException;
 use PHPUnit\Framework\TestCase;
 use function exec;
 use function sleep;
@@ -53,7 +53,7 @@ class GitTest extends TestCase
 
     public function testThatAnExceptionIsThrownIfNoMatchingTagIsFound(): void
     {
-        $this->expectException(RepositoryNotFoundException::class);
+        $this->expectException(ReleaseNotFoundException::class);
 
         $git = new Git();
 
@@ -64,7 +64,7 @@ class GitTest extends TestCase
     {
         $this->createTag('foo');
 
-        $this->expectException(RepositoryNotFoundException::class);
+        $this->expectException(ReleaseNotFoundException::class);
 
         $git = new Git();
 
@@ -96,7 +96,6 @@ class GitTest extends TestCase
     {
         $git = new Git();
 
-        $this->expectException(RepositoryNotFoundException::class);
         $commits = $git->getCommitsSinceLastVersion();
 
         $this->assertCount(1, $commits);

--- a/tests/integration/Vcs/GitTest.php
+++ b/tests/integration/Vcs/GitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Leviy\ReleaseTool\Tests\Integration\Vcs;
 
 use Leviy\ReleaseTool\Vcs\Git;
-use Leviy\ReleaseTool\Vcs\ReleaseNotFoundException;
+use Leviy\ReleaseTool\Vcs\RepositoryNotFoundException;
 use PHPUnit\Framework\TestCase;
 use function exec;
 use function sleep;
@@ -53,7 +53,7 @@ class GitTest extends TestCase
 
     public function testThatAnExceptionIsThrownIfNoMatchingTagIsFound(): void
     {
-        $this->expectException(ReleaseNotFoundException::class);
+        $this->expectException(RepositoryNotFoundException::class);
 
         $git = new Git();
 
@@ -64,7 +64,7 @@ class GitTest extends TestCase
     {
         $this->createTag('foo');
 
-        $this->expectException(ReleaseNotFoundException::class);
+        $this->expectException(RepositoryNotFoundException::class);
 
         $git = new Git();
 
@@ -95,6 +95,8 @@ class GitTest extends TestCase
     public function testThatCommitsSinceTheFirstCommitAreReturnedIfNoReleasesExist(): void
     {
         $git = new Git();
+
+        $this->expectException(RepositoryNotFoundException::class);
         $commits = $git->getCommitsSinceLastVersion();
 
         $this->assertCount(1, $commits);

--- a/tests/unit/Vcs/GitTest.php
+++ b/tests/unit/Vcs/GitTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Leviy\ReleaseTool\Tests\Unit\Vcs;
+
+use Leviy\ReleaseTool\Vcs\Git;
+use Leviy\ReleaseTool\Vcs\RepositoryNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class GitTest extends TestCase
+{
+    public function testThatAnExceptionIsThrownIfNoGitDirectoryIsPresent(): void
+    {
+        $this->expectException(RepositoryNotFoundException::class);
+
+        Git::execute('status');
+    }
+}


### PR DESCRIPTION
[#42] The release tool shows a fatal error when its called outside a git repository.

It has to show a cleaner error when called outside a git directory.