### PR TITLE
Enable compression

### DIFF
--- a/box.json
+++ b/box.json
@@ -5,6 +5,7 @@
     "directories-bin": [
         "config"
     ],
+    "compression": "GZ",
     "force-autodiscovery": true,
     "git-version": "package_version",
     "output": "build/release-tool.phar"


### PR DESCRIPTION
A filesize of 2.5 MB for such a simple tool is a lot.
Enabling compression for the phar brings it down to ~800KB.